### PR TITLE
Behaviour 停止時のイベントを追加

### DIFF
--- a/Assets/Scripts/UniRx/UnityEngineBridge/Triggers/PlayableBehaviourExtensions.cs
+++ b/Assets/Scripts/UniRx/UnityEngineBridge/Triggers/PlayableBehaviourExtensions.cs
@@ -20,6 +20,10 @@ namespace UniRx.Triggers {
             return component.GetOrAddObservablePlayableBehaviourTrigger().OnBehaviourPauseAsObservable();
         }
 
+        public static IObservable<ObservablePlayableBehaviourTrigger.Information> OnBehaviourStopAsObservable(this Component component) {
+            return component.GetOrAddObservablePlayableBehaviourTrigger().OnBehaviourPlayAsObservable().SelectMany(component.GetOrAddObservablePlayableBehaviourTrigger().OnBehaviourPauseAsObservable());
+        }
+
         public static IObservable<ObservablePlayableBehaviourTrigger.Information> PrepareFrameAsObservable(this Component component) {
             return component.GetOrAddObservablePlayableBehaviourTrigger().PrepareFrameAsObservable();
         }


### PR DESCRIPTION
* OnBehaviourPauseAsObservable() だと開始時にも呼ばれてしまう（っぽい）ので、「開始」->「停止」の流れにより発火するストリームを追加実装