### PR TITLE
OnBehaviourStopAsObservable が不正に2重起動されることがあるバグを修正

### DIFF
--- a/Assets/Scripts/UniRx/UnityEngineBridge/Triggers/PlayableBehaviourExtensions.cs
+++ b/Assets/Scripts/UniRx/UnityEngineBridge/Triggers/PlayableBehaviourExtensions.cs
@@ -21,7 +21,7 @@ namespace UniRx.Triggers {
         }
 
         public static IObservable<ObservablePlayableBehaviourTrigger.Information> OnBehaviourStopAsObservable(this Component component) {
-            return component.GetOrAddObservablePlayableBehaviourTrigger().OnBehaviourPlayAsObservable().SelectMany(component.GetOrAddObservablePlayableBehaviourTrigger().OnBehaviourPauseAsObservable());
+            return component.GetOrAddObservablePlayableBehaviourTrigger().OnBehaviourPlayAsObservable().SelectMany(component.GetOrAddObservablePlayableBehaviourTrigger().OnBehaviourPauseAsObservable().Take(1));
         }
 
         public static IObservable<ObservablePlayableBehaviourTrigger.Information> PrepareFrameAsObservable(this Component component) {


### PR DESCRIPTION
* 1回 Play → Pause を行ったストリームの場合、Pause の Subject が生きている所為で次に Play が走った瞬間に Stop 扱いになってしまう
* Pause のストリームを `.Take(1)` で確実に閉じるようにすることで回避